### PR TITLE
Refactor acceptance rate calculation in MetricsViewer.vue

### DIFF
--- a/src/components/MetricsViewer.vue
+++ b/src/components/MetricsViewer.vue
@@ -259,7 +259,7 @@ export default defineComponent({
       sum += rate;
       return rate;
     });
-    acceptanceRateAverage.value = sum / data.length;
+    
 
     acceptanceRateChartData.value = {
       labels: data.map((m: Metrics) => m.day),
@@ -274,6 +274,8 @@ export default defineComponent({
         }
       ]
     };
+
+    acceptanceRateAverage.value = cumulativeNumberAcceptances.value / cumulativeNumberSuggestions.value * 100;
 
     totalActiveUsersChartData.value = {
       labels: data.map((m: Metrics) => m.day),

--- a/src/components/MetricsViewer.vue
+++ b/src/components/MetricsViewer.vue
@@ -252,11 +252,9 @@ export default defineComponent({
         }
       ]
     };
-
-    let sum = 0;
+    
     const acceptanceRates = data.map((m: Metrics) => {
       const rate = m.total_lines_suggested !== 0 ? (m.total_lines_accepted / m.total_lines_suggested) * 100 : 0;
-      sum += rate;
       return rate;
     });
     
@@ -274,8 +272,12 @@ export default defineComponent({
         }
       ]
     };
-
-    acceptanceRateAverage.value = cumulativeNumberAcceptances.value / cumulativeNumberSuggestions.value * 100;
+    
+    if(cumulativeNumberSuggestions.value === 0){
+      acceptanceRateAverage.value = 0;
+    } else {
+      acceptanceRateAverage.value = cumulativeNumberAcceptances.value / cumulativeNumberSuggestions.value * 100;
+    }
 
     totalActiveUsersChartData.value = {
       labels: data.map((m: Metrics) => m.day),


### PR DESCRIPTION
This pull request primarily focuses on refactoring the calculation of the `acceptanceRateAverage` in the `MetricsViewer.vue` file. The calculation is now based on the cumulative number of acceptances and suggestions, rather than the average of daily acceptance rates.

Here are the key changes:

* [`src/components/MetricsViewer.vue`](diffhunk://#diff-3232f8c11e48e57eba48531f39e477604432e91bafd81119783d472a38ad3f10L256-R260): Removed the `sum` variable and its incrementation within the `acceptanceRates` map function. The `acceptanceRateAverage` value is no longer calculated within this function.
* [`src/components/MetricsViewer.vue`](diffhunk://#diff-3232f8c11e48e57eba48531f39e477604432e91bafd81119783d472a38ad3f10R276-R281): Added a conditional to check if `cumulativeNumberSuggestions` is zero. If it is, `acceptanceRateAverage` is set to zero. Otherwise, `acceptanceRateAverage` is calculated based on `cumulativeNumberAcceptances` and `cumulativeNumberSuggestions`. 