### PR TITLE
chore: Bump version to 1.5.0 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-metrics-viewer",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-metrics-viewer",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "@mdi/font": "5.9.55",
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-metrics-viewer",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",


### PR DESCRIPTION
This pull request includes a minor update to the `package.json` file. The version of the `copilot-metrics-viewer` package has been incremented from `1.4.0` to `1.5.0`.