### PR TITLE
add seat analysis support for Github Enterprise, since newly released…

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ The language breakdown analysis tab also displays a table showing the Accepted P
 
 ## Seat Analysis 
 
-![image](https://github.com/DevOps-zhuang/copilot-metrics-viewer/assets/54096296/d1fa9d1d-4fab-4e87-84ba-7be189dd4dd0)
+![image](https://private-user-images.githubusercontent.com/54096296/334353713-d1fa9d1d-4fab-4e87-84ba-7be189dd4dd0.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTg5ODc0MTYsIm5iZiI6MTcxODk4NzExNiwicGF0aCI6Ii81NDA5NjI5Ni8zMzQzNTM3MTMtZDFmYTlkMWQtNGZhYi00ZTg3LTg0YmEtN2JlMTg5ZGQ0ZGQwLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA2MjElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNjIxVDE2MjUxNlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTE1MWE2YmEwYThkODU5MGVmZDc1MDZjNWY5M2MzNzQzNzFjNTZjNjA1Njk0ZDdhZjc1ZjQ5YWJhYjcxMmRiYmEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.rjuRIhggtvKfIXZxCnQQSsDqrhOt1_jK3jdbbDvn2_A)
 
-1. **Total Assigned:** This metric represents the total number of Copilot seats assigned within current organization.
+1. **Total Assigned:** This metric represents the total number of Copilot seats assigned within current organization/enterprise.
 
-2. **Assigned But Never Used:** This metric shows seats that were assigned but never within the current organization. The assigned timestamp is also displayed in the below chart.
+2. **Assigned But Never Used:** This metric shows seats that were assigned but never within the current organization/enterprise. The assigned timestamp is also displayed in the below chart.
 
 3. **No Activity in the Last 7 days:** never used seats or seats used, but with no activity in the past 7 days.
 

--- a/README.md
+++ b/README.md
@@ -71,17 +71,16 @@ The language breakdown analysis tab also displays a table showing the Accepted P
 4. **Total Active Copilot Chat Users:** a bar chart that illustrates the total number of users who have actively interacted with Copilot over the past 28 days.
 
 ## Seat Analysis 
-
-![image](https://private-user-images.githubusercontent.com/54096296/334353713-d1fa9d1d-4fab-4e87-84ba-7be189dd4dd0.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTg5ODc0MTYsIm5iZiI6MTcxODk4NzExNiwicGF0aCI6Ii81NDA5NjI5Ni8zMzQzNTM3MTMtZDFmYTlkMWQtNGZhYi00ZTg3LTg0YmEtN2JlMTg5ZGQ0ZGQwLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA2MjElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNjIxVDE2MjUxNlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTE1MWE2YmEwYThkODU5MGVmZDc1MDZjNWY5M2MzNzQzNzFjNTZjNjA1Njk0ZDdhZjc1ZjQ5YWJhYjcxMmRiYmEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.rjuRIhggtvKfIXZxCnQQSsDqrhOt1_jK3jdbbDvn2_A)
-
+<p align="center">
+  <img width="800" alt="image" src="https://github.com/github-copilot-resources/copilot-metrics-viewer/assets/54096296/51747194-df30-4bfb-8849-54a0510fffcb">
+</p>
 1. **Total Assigned:** This metric represents the total number of Copilot seats assigned within current organization/enterprise.
 
-2. **Assigned But Never Used:** This metric shows seats that were assigned but never within the current organization/enterprise. The assigned timestamp is also displayed in the below chart.
+2. **Assigned But Never Used:** This metric shows seats that were assigned but never within the current organization/enterprise. The assigned timestamp is also displayed in the chart.
 
 3. **No Activity in the Last 7 days:** never used seats or seats used, but with no activity in the past 7 days.
 
 4. **No Activity in the last 7 days (including never used seats):** a table to display seats that have had no activity in the past 7 days, ordered by the date of last activity. Seats that were used earlier are displayed at the top.
-
 
 
 ## Setup instructions

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The language breakdown analysis tab also displays a table showing the Accepted P
 </p>
 1. **Total Assigned:** This metric represents the total number of Copilot seats assigned within current organization/enterprise.
 
-2. **Assigned But Never Used:** This metric shows seats that were assigned but never within the current organization/enterprise. The assigned timestamp is also displayed in the chart.
+2. **Assigned But Not Used (in the last 28 days):** This metric shows seats that were assigned but not used during the last 28 days within the current organization/enterprise. The assigned timestamp is also displayed in the chart.”
 
 3. **No Activity in the Last 7 days:** never used seats or seats used, but with no activity in the past 7 days.
 

--- a/src/api/ExtractSeats.ts
+++ b/src/api/ExtractSeats.ts
@@ -8,21 +8,64 @@ import enterpriseMockedResponse_seats from '../assets/enterprise_response_sample
 export const getSeatsApi = async (): Promise<Seat[]> => {
   const perPage = 50;
   let page = 1;
+  let seatUrl = `https://api.github.com/`;
   let seatsData: Seat[] = [];
 
   let response;
-  if (process.env.VUE_APP_SCOPE !== "organization") {
-    // when the scope is not organization, return seatsData,by default it will return empty array
-    return seatsData;
-  }
-  else{
-    if (process.env.VUE_APP_MOCKED_DATA === "true") {
-      response = organizationMockedResponse_seats;
+  
+
+  if (process.env.VUE_APP_MOCKED_DATA === "true") {
+    console.log("Using mock data. Check VUE_APP_MOCKED_DATA variable.");
+      if (process.env.VUE_APP_SCOPE === "organization") {
+        response = organizationMockedResponse_seats;
+      } 
+      else if (process.env.VUE_APP_SCOPE === "enterprise") {
+        response = enterpriseMockedResponse_seats;
+      }
+      else {
+        throw new Error(`Invalid VUE_APP_SCOPE value: ${process.env.VUE_APP_SCOPE}. Expected "organization" or "enterprise".`);
+      }
       seatsData = seatsData.concat(response.seats.map((item: any) => new Seat(item)));
-    } 
-    else if (process.env.VUE_APP_MOCKED_DATA === "false") {
+      return seatsData;
+  }
+  else {
+    // if VUE_APP_GITHUB_TOKEN is not set, throw an error
+    if (!process.env.VUE_APP_GITHUB_TOKEN) {
+      throw new Error("VUE_APP_GITHUB_TOKEN environment variable is not set.");
+      return seatsData;
+    }
+    else if (process.env.VUE_APP_SCOPE === "organization") {
+      seatUrl=seatUrl+`orgs/${process.env.VUE_APP_GITHUB_ORG}/copilot/billing/seats`;
+    }
+    else if (process.env.VUE_APP_SCOPE === "enterprise") {
+      seatUrl=seatUrl+`enterprises/${process.env.VUE_APP_GITHUB_ENT}/copilot/billing/seats`;
+    }
+    else {
+      throw new Error(`Invalid VUE_APP_SCOPE value: ${process.env.VUE_APP_SCOPE}. Expected "organization" or "enterprise".`);
+      return seatsData;
+    }
+
     // Fetch the first page to get the total number of seats
-      response = await axios.get(`https://api.github.com/orgs/${process.env.VUE_APP_GITHUB_ORG}/copilot/billing/seats`, {
+    response = await axios.get(seatUrl, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${process.env.VUE_APP_GITHUB_TOKEN}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      params: {
+        per_page: perPage,
+        page: page
+      }
+    });
+
+    seatsData = seatsData.concat(response.data.seats.map((item: any) => new Seat(item)));
+    // Calculate the total pages
+    const totalSeats = response.data.total_seats;
+    const totalPages = Math.ceil(totalSeats / perPage);
+
+    // Fetch the remaining pages
+    for (page = 2; page <= totalPages; page++) {
+      response = await axios.get(seatUrl, {
         headers: {
           Accept: "application/vnd.github+json",
           Authorization: `Bearer ${process.env.VUE_APP_GITHUB_TOKEN}`,
@@ -33,29 +76,8 @@ export const getSeatsApi = async (): Promise<Seat[]> => {
           page: page
         }
       });
-
       seatsData = seatsData.concat(response.data.seats.map((item: any) => new Seat(item)));
-      // Calculate the total pages
-      const totalSeats = response.data.total_seats;
-      const totalPages = Math.ceil(totalSeats / perPage);
-
-      // Fetch the remaining pages
-      for (page = 2; page <= totalPages; page++) {
-        response = await axios.get(`https://api.github.com/orgs/${process.env.VUE_APP_GITHUB_ORG}/copilot/billing/seats`, {
-          headers: {
-            Accept: "application/vnd.github+json",
-            Authorization: `Bearer ${process.env.VUE_APP_GITHUB_TOKEN}`,
-            "X-GitHub-Api-Version": "2022-11-28",
-          },
-          params: {
-            per_page: perPage,
-            page: page
-          }
-        });
-
-        seatsData = seatsData.concat(response.data.seats.map((item: any) => new Seat(item)));
-      } //end of else if (process.env.VUE_APP_MOCKED_DATA === "false")
-  }  //end of else if (process.env.VUE_APP_SCOPE !== "organization")
-  return seatsData;
-}
-}
+    }
+    return seatsData;
+    } 
+  }

--- a/src/assets/enterprise_response_sample_seats.json
+++ b/src/assets/enterprise_response_sample_seats.json
@@ -8,7 +8,7 @@
         "last_activity_at": "2021-10-14T00:53:32-06:00",
         "last_activity_editor": "vscode/1.77.3/copilot/1.86.82",
         "assignee": {
-          "login": "octocat",
+          "login": "octocat_byEnterprise",
           "id": 1,
           "node_id": "MDQ6VXNlcjE=",
           "avatar_url": "https://github.com/images/error/octocat_happy.gif",

--- a/src/assets/organization_response_sample_seats.json
+++ b/src/assets/organization_response_sample_seats.json
@@ -8,7 +8,7 @@
         "last_activity_at": "2021-10-14T00:53:32-06:00",
         "last_activity_editor": "vscode/1.77.3/copilot/1.86.82",
         "assignee": {
-          "login": "octocat",
+          "login": "octocat_org",
           "id": 1,
           "node_id": "MDQ6VXNlcjE=",
           "avatar_url": "https://github.com/images/error/octocat_happy.gif",
@@ -50,7 +50,7 @@
         "last_activity_at": "2021-10-13T00:53:32-06:00",
         "last_activity_editor": "vscode/1.77.3/copilot/1.86.82",
         "assignee": {
-          "login": "octokitten",
+          "login": "octokitten_org",
           "id": 1,
           "node_id": "MDQ76VNlcjE=",
           "avatar_url": "https://github.com/images/error/octokitten_happy.gif",

--- a/src/components/ApiResponse.vue
+++ b/src/components/ApiResponse.vue
@@ -13,7 +13,8 @@
       </div>
       
       <br><br>
-    <div v-if="vueAppScope === 'organization'">
+    <!--<div v-if="vueAppScope === 'organization'">-->
+  
       <v-card max-height="575px" class="overflow-y-auto">
           <pre ref="jsonText">{{ JSON.stringify(seats, null, 2) }}</pre>
       </v-card>
@@ -24,7 +25,6 @@
           <div v-if="showSeatMessage" :class="{'copy-message': true, 'error': isError}">{{ message }}</div>
         </transition>
       </div>
-    </div>
   </v-container>
 </template>
 

--- a/src/components/ApiResponse.vue
+++ b/src/components/ApiResponse.vue
@@ -13,7 +13,6 @@
       </div>
       
       <br><br>
-    <!--<div v-if="vueAppScope === 'organization'">-->
   
       <v-card max-height="575px" class="overflow-y-auto">
           <pre ref="jsonText">{{ JSON.stringify(seats, null, 2) }}</pre>

--- a/src/components/MainComponent.vue
+++ b/src/components/MainComponent.vue
@@ -100,14 +100,6 @@ export default defineComponent({
     if(this.itemName !== 'invalid'){
       this.tabItems.unshift(this.itemName);
     }
-    /* if (process.env.VUE_APP_SCOPE === 'organization') {
-      // get the last item in the array,which is 'api response' 
-      //and add 'seat analysis' before it
-      let lastItem = this.tabItems.pop();
-      this.tabItems.push('seat analysis');
-      if (lastItem) {
-        this.tabItems.push(lastItem);
-      }
   },
   setup() {
       const metricsReady = ref(false);

--- a/src/components/MainComponent.vue
+++ b/src/components/MainComponent.vue
@@ -31,7 +31,6 @@
               <BreakdownComponent v-if="item === 'languages'" :metrics="metrics" :breakdownKey="'language'"/>
               <BreakdownComponent v-if="item === 'editors'" :metrics="metrics" :breakdownKey="'editor'"/>
               <CopilotChatViewer v-if="item === 'copilot chat'" :metrics="metrics" />
-              <!--<div v-if="isScopeOrganization">-->
                 <SeatsAnalysisViewer v-if="item === 'seat analysis'" :seats="seats" />
               <!--</div>-->
               <ApiResponse v-if="item === 'api response'" :metrics="metrics" :seats="seats" />

--- a/src/components/MainComponent.vue
+++ b/src/components/MainComponent.vue
@@ -31,9 +31,9 @@
               <BreakdownComponent v-if="item === 'languages'" :metrics="metrics" :breakdownKey="'language'"/>
               <BreakdownComponent v-if="item === 'editors'" :metrics="metrics" :breakdownKey="'editor'"/>
               <CopilotChatViewer v-if="item === 'copilot chat'" :metrics="metrics" />
-              <div v-if="isScopeOrganization">
+              <!--<div v-if="isScopeOrganization">-->
                 <SeatsAnalysisViewer v-if="item === 'seat analysis'" :seats="seats" />
-              </div>
+              <!--</div>-->
               <ApiResponse v-if="item === 'api response'" :metrics="metrics" :seats="seats" />
             </v-card>
           </v-window-item>
@@ -94,7 +94,7 @@ export default defineComponent({
   },
   data () {
     return {
-      tabItems: ['languages', 'editors', 'copilot chat', 'api response'],
+      tabItems: ['languages', 'editors', 'copilot chat','seat analysis' , 'api response'],
       tab: null
     }
   },
@@ -102,7 +102,7 @@ export default defineComponent({
     if(this.itemName !== 'invalid'){
       this.tabItems.unshift(this.itemName);
     }
-    if (process.env.VUE_APP_SCOPE === 'organization') {
+    /* if (process.env.VUE_APP_SCOPE === 'organization') {
       // get the last item in the array,which is 'api response' 
       //and add 'seat analysis' before it
       let lastItem = this.tabItems.pop();
@@ -110,7 +110,7 @@ export default defineComponent({
       if (lastItem) {
         this.tabItems.push(lastItem);
       }
-    }
+    } */
   },
   setup() {
       const metricsReady = ref(false);

--- a/src/components/MainComponent.vue
+++ b/src/components/MainComponent.vue
@@ -108,7 +108,6 @@ export default defineComponent({
       if (lastItem) {
         this.tabItems.push(lastItem);
       }
-    } */
   },
   setup() {
       const metricsReady = ref(false);

--- a/src/components/MainComponent.vue
+++ b/src/components/MainComponent.vue
@@ -32,7 +32,6 @@
               <BreakdownComponent v-if="item === 'editors'" :metrics="metrics" :breakdownKey="'editor'"/>
               <CopilotChatViewer v-if="item === 'copilot chat'" :metrics="metrics" />
                 <SeatsAnalysisViewer v-if="item === 'seat analysis'" :seats="seats" />
-              <!--</div>-->
               <ApiResponse v-if="item === 'api response'" :metrics="metrics" :seats="seats" />
             </v-card>
           </v-window-item>

--- a/src/components/SeatsAnalysisViewer.vue
+++ b/src/components/SeatsAnalysisViewer.vue
@@ -17,9 +17,9 @@
             <v-card-item class="d-flex justify-center align-center">
                 <div class="tiles-text">
                     <div class="text-overline mb-1" style="visibility: hidden;">filler</div>
-                    <div class="text-h6 mb-1">Assigned But Never Used</div>
+                    <div class="text-h6 mb-1">Assigned But Not Used</div>
                     <div class="text-caption">
-                        No show seats
+                        No show seats in the past 28 days
                     </div>
                     <p class="text-h4">{{ NoshowSeats.length }}</p>
                 </div>

--- a/src/components/SeatsAnalysisViewer.vue
+++ b/src/components/SeatsAnalysisViewer.vue
@@ -104,7 +104,7 @@ data() {
         headers: [
             { title: 'Login', key: 'login' },
             { title: 'GitHub ID', key: 'id' },
-            { title: 'Assigning_team', key: 'team' },
+            { title: 'Assigning team', key: 'team' },
             { title: 'Assigned time', key: 'created_at' },
             { title: 'Last Activity At', key: 'last_activity_at' },
             { title: 'Last Activity Editor', key: 'last_activity_editor' },

--- a/src/components/SeatsAnalysisViewer.vue
+++ b/src/components/SeatsAnalysisViewer.vue
@@ -50,6 +50,7 @@
                     <tr>
                         <td>{{ item.login }}</td>
                         <td>{{ item.id }}</td>
+                        <td>{{ item.team }}</td>
                         <td>{{ item.created_at }}</td>
                         <td>{{ item.last_activity_at }}</td>
                         <td>{{ item.last_activity_editor }}</td>
@@ -103,7 +104,8 @@ data() {
         headers: [
             { title: 'Login', key: 'login' },
             { title: 'GitHub ID', key: 'id' },
-            { title: 'Assigned to the Organization At', key: 'created_at' },
+            { title: 'Assigning_team', key: 'team' },
+            { title: 'Assigned time', key: 'created_at' },
             { title: 'Last Activity At', key: 'last_activity_at' },
             { title: 'Last Activity Editor', key: 'last_activity_editor' },
         ],

--- a/src/model/Seat.ts
+++ b/src/model/Seat.ts
@@ -1,6 +1,7 @@
 export class Seat {
     login: string;
     id: number;
+    team: string;
     created_at: string;
     last_activity_at: string;
     last_activity_editor: string;
@@ -8,7 +9,8 @@ export class Seat {
     constructor(data: any) {
         this.login = data.assignee.login;
         this.id = data.assignee.id;
-         this.created_at = data.created_at;
+        this.team = data.assigning_team ? data.assigning_team.name : '';
+        this.created_at = data.created_at;
         this.last_activity_at = data.last_activity_at;
         this.last_activity_editor = data.last_activity_editor;
     }


### PR DESCRIPTION
Add seat analysis support for Github Enterprise, since newly released Github API support enterprise level seat information in 6/21, thanks for check.

_https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#list-all-copilot-seat-assignments-for-an-enterprise_

Updates to the README:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R74-L86): The image source and some descriptions in the `Seat Analysis` section have been updated to reflect the current state of the project.

Changes to the `getSeatsApi` function:

* [`src/api/ExtractSeats.ts`](diffhunk://#diff-72433de4a75976d16d921f968a55213c0628b3f14104deb8ff7db25bd61dd12aR11-R49): The `getSeatsApi` function has been modified to handle both "organization" and "enterprise" scopes. It now constructs the API URL based on the `VUE_APP_SCOPE` environment variable. The function also uses the `VUE_APP_GITHUB_TOKEN` environment variable and throws an error if it's not set. [[1]](diffhunk://#diff-72433de4a75976d16d921f968a55213c0628b3f14104deb8ff7db25bd61dd12aR11-R49) [[2]](diffhunk://#diff-72433de4a75976d16d921f968a55213c0628b3f14104deb8ff7db25bd61dd12aL44-R68) [[3]](diffhunk://#diff-72433de4a75976d16d921f968a55213c0628b3f14104deb8ff7db25bd61dd12aL55-R80)

Changes to the `Seat` model:

* [`src/model/Seat.ts`](diffhunk://#diff-86979938ee4b2f3dce6e459738fa7566101e9ab1e28d186192563634d0b6f354R4-R12): A new property `team` has been added to the `Seat` model.

Changes to the sample response data:

* `src/assets/enterprise_response_sample_seats.json` and `src/assets/organization_response_sample_seats.json`: The `login` property of the `assignee` object has been updated in the sample response data. [[1]](diffhunk://#diff-00fdb9f4d99517cd43371dee7fb7dfd307f4c11239afe022510e93b0c5e3eebaL11-R11) [[2]](diffhunk://#diff-25bafe423beee82e368f3e2875b633596660477fd258e41d72705dc54f5e5cb1L11-R11) [[3]](diffhunk://#diff-25bafe423beee82e368f3e2875b633596660477fd258e41d72705dc54f5e5cb1L53-R53)

Changes to the Vue components:

* [`src/components/SeatsAnalysisViewer.vue`](diffhunk://#diff-ab0ce56718bd87d55c7b6acfbd15c636826f0bdcd0fa3a836d950a609736f09cR53): The `team` property has been added to the table in the `SeatsAnalysisViewer` component. [[1]](diffhunk://#diff-ab0ce56718bd87d55c7b6acfbd15c636826f0bdcd0fa3a836d950a609736f09cR53) [[2]](diffhunk://#diff-ab0ce56718bd87d55c7b6acfbd15c636826f0bdcd0fa3a836d950a609736f09cL106-R108)
* `src/components/ApiResponse.vue` and `src/components/MainComponent.vue`: Some conditional rendering based on the `vueAppScope` and `isScopeOrganization` properties have been commented out. [[1]](diffhunk://#diff-0b3857f49e9bfcf881b2f87a8a87330f654e136b039ee996337362417973d6f6L16-R17) [[2]](diffhunk://#diff-0b3857f49e9bfcf881b2f87a8a87330f654e136b039ee996337362417973d6f6L27) [[3]](diffhunk://#diff-e9eea4ec690e7649e2f812dfa7620e6200d892450dceb379d53e72f9be2894afL34-R36) [[4]](diffhunk://#diff-e9eea4ec690e7649e2f812dfa7620e6200d892450dceb379d53e72f9be2894afL97-R113)