### PR TITLE
chore: Update GitHub Personal Access Token scopes in .env and README

### DIFF
--- a/.env
+++ b/.env
@@ -11,5 +11,5 @@ VUE_APP_GITHUB_ORG=octodemo
 VUE_APP_GITHUB_ENT=
 
 # Determines the GitHub Personal Access Token to use for API calls.
-# Create with scopes copilot, manage_billing:copilot, admin:enterprise, or manage_billing:enterprise, read:enterprise AND read:org
+# Create with scopes copilot, manage_billing:copilot or manage_billing:enterprise, read:enterprise AND read:org
 VUE_APP_GITHUB_TOKEN=

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ To access Copilot metrics from the last 28 days via the API and display actual d
 ```
 
 #### VUE_APP_GITHUB_TOKEN
-Specifies the GitHub Personal Access Token utilized for API requests. Generate this token with the following scopes: _copilot_, _manage_billing:copilot_, _manage_billing:enterprise_, _read:enterprise_, _admin:org_.
+Specifies the GitHub Personal Access Token utilized for API requests. Generate this token with the following scopes: _copilot_, _manage_billing:copilot_, _manage_billing:enterprise_, _read:enterprise_, _read:org_.
 
 ```
   VUE_APP_GITHUB_TOKEN=


### PR DESCRIPTION
This pull request includes changes to the `.env` file and the `README.md` file. The changes primarily involve the modification of the scopes required for the GitHub Personal Access Token used for API calls.