### PR TITLE
add serial number in the seat analysis tab

### DIFF
--- a/src/components/SeatsAnalysisViewer.vue
+++ b/src/components/SeatsAnalysisViewer.vue
@@ -46,8 +46,9 @@
                 <h2>All assigned seats </h2>
                 <br>
             <v-data-table :headers="headers" :items="totalSeats" :items-per-page="10" class="elevation-2">
-                <template v-slot:item="{ item }">
+                <template v-slot:item="{ item, index }">
                     <tr>
+                        <td>{{ index + 1 }}</td>
                         <td>{{ item.login }}</td>
                         <td>{{ item.id }}</td>
                         <td>{{ item.team }}</td>
@@ -102,6 +103,7 @@ props: {
 data() {
     return {
         headers: [
+            { title: 'S.No', key: 'serialNumber'},
             { title: 'Login', key: 'login' },
             { title: 'GitHub ID', key: 'id' },
             { title: 'Assigning team', key: 'team' },


### PR DESCRIPTION
Added serial number in the **Seat Analysis** tab, see screen shot below

<img width="1580" alt="image" src="https://github.com/github-copilot-resources/copilot-metrics-viewer/assets/31553320/cf2b8f30-f39e-48a7-83f0-9eee554e9ad8">

This is useful when the number of seats are 100+

_Not a **js** programmer, used GH copilot :)_
