### PR TITLE
Bump production-stage image to nginx:1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN npm run build
 
 # Stage 2: Serve the application with Nginx
-FROM nginx:1.19 as production-stage
+FROM nginx:1.26 as production-stage
 COPY --from=build-stage /app/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Bumping the production-stage container image from `nginx:1.19` to `nginx:1.26` should eliminate more than 200 vulnerability findings - including 34 CVEs rated at critical (as of 11-Jul-2024).

**Prisma Twistlock Summary using `nginx1.19`**

Vulnerabilities found for image `ghcr.io/github-copilot-resources/copilot-metrics-viewer:latest`:

- total - 201
- critical - 34
- high - 72
- medium - 95
- low - 0

[copilot-metrics-viewer__vulnerability_scan_7_12_24_12_02_41.csv](https://github.com/user-attachments/files/16192796/copilot-metrics-viewer__twistlock_scans_7_12_24_12_02_41.csv)
