### PR TITLE
Fix regression on the Enterprise tabs

### DIFF
--- a/src/components/MainComponent.vue
+++ b/src/components/MainComponent.vue
@@ -88,7 +88,7 @@ export default defineComponent({
   },
   data () {
     return {
-      tabItems: ['languages', 'editors', 'copilot chat','seat analysis' , 'api response'],
+      tabItems: ['languages', 'editors', 'copilot chat', 'api response'],
       tab: null
     }
   },


### PR DESCRIPTION
This pull request fixes a regression on the Enterprise tabs. Previously, the 'seat analysis' tab was included in the tabItems array, but it has been removed in this PR to resolve the regression. Now, the tabItems array only includes the 'languages', 'editors', 'copilot chat', and 'api response' tabs.