### PR TITLE
feat: Add workflows for building and pushing Docker images with custo…

### DIFF
--- a/.github/workflows/deploy_to_ghcr_custom_tag.yaml
+++ b/.github/workflows/deploy_to_ghcr_custom_tag.yaml
@@ -1,0 +1,36 @@
+name: Build and push Docker image with custom tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag for the Docker image'
+        required: true
+        default: 'latest'
+
+permissions:
+  packages: write
+
+jobs:
+  push_to_ghcr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout GitHub Action
+        uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Docker Image
+        run: |
+          GITHUB_REPO="${GITHUB_REPO,,}"  # convert repo name to lowercase as required by docker
+          TAG=${{ github.event.inputs.tag }}
+          echo "building docker image in repository '$GITHUB_REPO' with tag '$TAG' ..."
+          docker build --label "org.opencontainers.image.title=copilot-metrics-viewer" --label "org.opencontainers.image.description=Metrics viewer for GitHub Copilot usage" --label "org.opencontainers.image.source=$GITHUB_REPO" -t ghcr.io/$GITHUB_REPO:$TAG .
+          docker push ghcr.io/$GITHUB_REPO:$TAG
+        env:
+          GITHUB_REPO: ${{ github.repository }}

--- a/.github/workflows/deploy_to_ghcr_tag_release.yaml
+++ b/.github/workflows/deploy_to_ghcr_tag_release.yaml
@@ -1,0 +1,48 @@
+name: Build and push Docker image with release tag
+
+on:
+  
+  release:
+    types: 
+      - published
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  push_to_ghcr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout GitHub Action
+        uses: actions/checkout@v4
+
+      - name: Get Latest Release Tag
+        id: get_latest_release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const latestRelease = await github.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            return latestRelease.data.tag_name;
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Docker Image
+        run: |
+          GITHUB_REPO="${GITHUB_REPO,,}"  # convert repo name to lowercase as required by docker
+          TAG=${{ steps.get_latest_release.outputs.result }}
+          echo "building docker image in repository '$GITHUB_REPO' with tag '$TAG' ..."
+          docker build --label "org.opencontainers.image.title=copilot-metrics-viewer" --label "org.opencontainers.image.description=Metrics viewer for GitHub Copilot usage" --label "org.opencontainers.image.source=$GITHUB_REPO" -t ghcr.io/$GITHUB_REPO:$TAG .
+          docker push ghcr.io/$GITHUB_REPO:$TAG
+        env:
+          GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
This pull request includes new workflows for building and pushing Docker images to the GitHub Container Registry (GHCR). The changes introduce two separate workflows: one for custom tags and another for release tags.

