### PR TITLE
support for public gh app

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -65,8 +65,7 @@ export default defineNuxtConfig({
     github: {
       enabled: true,
       clientId: '',
-      clientSecret: '',
-      scope: ''
+      clientSecret: ''
     }
   },
   nitro: {
@@ -84,7 +83,7 @@ export default defineNuxtConfig({
     oauth: {
       github: {
         clientId: '',
-        clientSecret: '',
+        clientSecret: ''
       }
     },
     public: {
@@ -94,7 +93,8 @@ export default defineNuxtConfig({
       githubEnt: '',
       githubTeam: '',
       usingGithubAuth: false,
-      version
+      version,
+      isPublicApp: false
     }
   }
 })

--- a/server/routes/auth/github.get.ts
+++ b/server/routes/auth/github.get.ts
@@ -1,8 +1,12 @@
+import type FetchError from 'ofetch';
 
 export default defineOAuthGitHubEventHandler({
   config: {
   },
   async onSuccess(event, { user, tokens }) {
+    const config = useRuntimeConfig(event);
+    const logger = console;
+
     await setUserSession(event, {
       user: {
         githubId: user.id,
@@ -15,6 +19,38 @@ export default defineOAuthGitHubEventHandler({
       }
     }
     )
+
+    // need to check if this is public app (no default org/team/ent)
+    if (config.public.isPublicApp) {
+      try {
+        const installationsResponse = await $fetch('https://api.github.com/user/installations', {
+          headers: {
+            Authorization: `token ${tokens.access_token}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28'
+          }
+        }) as { installations: Array<{ account: { login: string } }> };
+
+        const installations = installationsResponse.installations;
+        const organizations = installations.map(installation => installation.account.login);
+
+        await setUserSession(event, {
+          organizations
+        });
+        logger.info('User organizations:', organizations);
+
+        if (organizations.length === 0) {
+          console.error('No organizations found for the user.');
+          return sendRedirect(event, '/?error=No organizations found for the user.');
+        }
+
+        return sendRedirect(event, `/orgs/${organizations[0]}`);
+      }
+      catch (error: FetchError) {
+        logger.error('Error fetching installations:', error);
+      }
+    }
+
     return sendRedirect(event, '/')
   },
   // Optional, will return a json error and 401 status code by default


### PR DESCRIPTION
When `NUXT_PUBLIC_IS_PUBLIC_APP` is set to true, application will read GitHub app installations for logged in user and redirect to the first organization on the returned list.