### PR TITLE
fix no show seats

### DIFF
--- a/app/components/SeatsAnalysisViewer.vue
+++ b/app/components/SeatsAnalysisViewer.vue
@@ -136,7 +136,7 @@ setup(props) {
                 thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
                 props.seats.forEach(seat => {
-                    if (!('last_activity_at' in seat) || seat.last_activity_at === null) {
+                    if(!Boolean(seat.last_activity_at)) {
                         noshowCount++;
                     } else {
                         const lastActivityDate = new Date(seat.last_activity_at);

--- a/app/components/SeatsAnalysisViewer.vue
+++ b/app/components/SeatsAnalysisViewer.vue
@@ -136,7 +136,7 @@ setup(props) {
                 thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
                 props.seats.forEach(seat => {
-                    if (seat.last_activity_at === null) {
+                    if (!('last_activity_at' in seat) || seat.last_activity_at === null) {
                         noshowCount++;
                     } else {
                         const lastActivityDate = new Date(seat.last_activity_at);


### PR DESCRIPTION
The "no show seats" are showing wrong numbers in case of the 'last_activity_at' property not present in the api response. This fixes the stats making the real "no show seats" visible.