### PR TITLE
Fix Authentication token expiration check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-metrics-viewer",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/modules/authentication.ts
+++ b/server/modules/authentication.ts
@@ -29,17 +29,14 @@ export async function authenticateAndGetGitHubHeaders(event: H3Event<EventHandle
     // https://nuxt.com/docs/guide/recipes/sessions-and-authentication
     const { secure } = await getUserSession(event);
 
-    // check if token is expired and get new one
-    if (secure && secure.expires_at < new Date(Date.now() - 30 * 1000)) {
-        // Token is expired or about to expire within 30 seconds
-        // we could refresh but unlikely dashboard is used for long periods
-        return buildHeaders('');
-    }
-
-    return buildHeaders(secure?.tokens.access_token || '');
+    return buildHeaders(secure?.tokens?.access_token || '');
 }
 
 function buildHeaders(token: string): Headers {
+    if (!token) {
+        throw new Error('GitHub token is required');
+    }
+
     return new Headers({
         Accept: "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",

--- a/server/modules/authentication.ts
+++ b/server/modules/authentication.ts
@@ -29,6 +29,13 @@ export async function authenticateAndGetGitHubHeaders(event: H3Event<EventHandle
     // https://nuxt.com/docs/guide/recipes/sessions-and-authentication
     const { secure } = await getUserSession(event);
 
+    // check if token is expired and get new one
+    if (secure?.expires_at && secure.expires_at < new Date(Date.now() - 30 * 1000)) {
+        // Token is expired or about to expire within 30 seconds
+        // we could refresh but unlikely dashboard is used for long periods
+        return buildHeaders('');
+    }
+
     return buildHeaders(secure?.tokens?.access_token || '');
 }
 


### PR DESCRIPTION
Closes #184 and #190.

Throw an error if a token does not exist when building the Authorization header.

When using the GitHub OAuth app to authenticate, this is the `secure` object:
```
secure {
  tokens: {
    access_token: 'ghu_xxxxxxxxxxxxxxxxxxx',
    token_type: 'bearer',
    scope: ''
  },
  expires_at: null
}
```

`expires_at` is null, so it always calls `buildHeaders` with an empty string (which doesn't make sense).

Removed this erroneous code and throw an error if the header is being built without a token.