### PR TITLE
Prevent 500 - GitHub token is required

### DIFF
--- a/server/modules/authentication.ts
+++ b/server/modules/authentication.ts
@@ -41,10 +41,6 @@ export async function authenticateAndGetGitHubHeaders(event: H3Event<EventHandle
 }
 
 function buildHeaders(token: string): Headers {
-    if (!token) {
-        throw new Error('GitHub token is required');
-    }
-
     return new Headers({
         Accept: "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",


### PR DESCRIPTION
Prevent an error 500 that happens when using GitHub authentication with a GitHub app.

<details> <summary>Error 500 Details</summary>

```
 ERROR  [request error] [unhandled] [GET] http://localhost:3000/.well-known/appspecific/com.chrome.devtools.json

 
ℹ Error: GitHub token is required

 ⁃ at buildHeaders (server/modules/authentication.ts:42:1)

   37 ┃      return buildHeaders(secure?.tokens?.access_token || '');
   38 ┃  }
   39 ┃  
   40 ┃  function buildHeaders(token: string): Headers {
   41 ┃          if (!token) {
 ❯ 42 ┃              throw new Error('GitHub token is required');
   43 ┃          }
   44 ┃  
   45 ┃      return new Headers({
   46 ┃          Accept: "application/vnd.github+json",
   47 ┃          "X-GitHub-Api-Version": "2022-11-28",

 ⁃ at authenticateAndGetGitHubHeaders (server/modules/authentication.ts:37:1)
 ⁃ at async Object.handler (server/middleware/github.ts:13:1)
 ⁃ at async Object.handler (node_modules/h3/dist/index.mjs:2003:19)
 ⁃ at async Server.toNodeHandle (node_modules/h3/dist/index.mjs:2295:7)
```

</details>

The configuration is the following:

```
NUXT_PUBLIC_IS_DATA_MOCKED=false
NUXT_PUBLIC_SCOPE=organization
NUXT_PUBLIC_GITHUB_ORG=xyz  
NUXT_PUBLIC_USING_GITHUB_AUTH=true
NUXT_SESSION_PASSWORD=xyz
NUXT_OAUTH_GITHUB_CLIENT_ID=xyz
NUXT_OAUTH_GITHUB_CLIENT_SECRET=xyz
```

Other environment variables (`NUXT_PUBLIC_GITHUB_ENT`, `NUXT_PUBLIC_GITHUB_TEAM`, `NUXT_OAUTH_GITHUB_CLIENT_SCOPE`, `HTTP_PROXY`) are not set 

