### PR TITLE
Fix OAuth authentication error on initial page load

### DIFF
--- a/server/middleware/github.ts
+++ b/server/middleware/github.ts
@@ -3,6 +3,14 @@ import { authenticateAndGetGitHubHeaders } from '../modules/authentication';
 type Scope = 'org' | 'team' | 'ent';
 
 export default defineEventHandler(async (event) => {
+    // Only apply authentication to API routes
+    const url = event.node.req.url || '';
+    
+    // Skip authentication for non-API routes
+    if (!url.startsWith('/api/')) {
+        return;
+    }
+    
     // get runtime config
     const config = useRuntimeConfig(event);
 


### PR DESCRIPTION
## Summary
- Modified GitHub middleware to only apply authentication to API routes
- Allows users to access the login page without authentication errors
- Preserves API endpoint security

## Problem
When using OAuth authentication (`NUXT_PUBLIC_USING_GITHUB_AUTH=true`) without a server-side GitHub token, users encountered a "GitHub token is required" error immediately upon visiting the application, before having a chance to sign in.

## Root Cause
The GitHub authentication middleware was running on **all server requests**, including:
- Initial page load (`/`)
- Static assets
- Auth routes (`/auth/github`)
- API routes (`/api/*`)

This created a catch-22 situation where users couldn't authenticate because they couldn't access the authentication page.

## Solution
Modified the middleware to only apply authentication requirements to API routes. This allows:
- Public access to the main application page
- Users to see and click the "Sign in with GitHub" button
- OAuth callback routes to function properly
- API routes to remain protected with authentication

## Testing
- [x] Initial page load without authentication works
- [x] OAuth sign-in flow works
- [x] API calls before authentication are properly rejected
- [x] API calls after authentication work with session token
- [x] Tests pass (`npm run test`)
- [x] Linting passes for modified file

## Related Issues
This provides an alternative solution to #206

🤖 Generated with [Claude Code](https://claude.ai/code)